### PR TITLE
feat: Implement PDF and DOCX content extraction

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,19 +1,19 @@
 {
   "name": "school-moodle-mcp",
-  "version": "0.2.9",
+  "version": "0.3.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "school-moodle-mcp",
-      "version": "0.2.9",
+      "version": "0.3.5",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0",
         "axios": "^1.6.2",
         "cheerio": "^1.0.0",
         "dotenv": "^16.4.5",
         "json-schema": "^0.4.0",
-        "mammoth": "^1.9.0",
+        "mammoth": "^1.9.1",
         "pdf-parse": "^1.1.1",
         "zod": "^3.22.4"
       },
@@ -3019,10 +3019,9 @@
       "license": "ISC"
     },
     "node_modules/mammoth": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/mammoth/-/mammoth-1.9.0.tgz",
-      "integrity": "sha512-F+0NxzankQV9XSUAuVKvkdQK0GbtGGuqVnND9aVf9VSeUA82LQa29GjLqYU6Eez8LHqSJG3eGiDW3224OKdpZg==",
-      "license": "BSD-2-Clause",
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/mammoth/-/mammoth-1.9.1.tgz",
+      "integrity": "sha512-4S2v1eP4Yo4so0zGNicJKcP93su3wDPcUk+xvkjSG75nlNjSkDJu8BhWQ+e54BROM0HfA6nPzJn12S6bq2Ko6w==",
       "dependencies": {
         "@xmldom/xmldom": "^0.8.6",
         "argparse": "~1.0.3",
@@ -3426,7 +3425,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/pdf-parse/-/pdf-parse-1.1.1.tgz",
       "integrity": "sha512-v6ZJ/efsBpGrGGknjtq9J/oC8tZWq0KWL5vQrk2GlzLEQPUDB1ex+13Rmidl1neNN358Jn9EHZw5y07FFtaC7A==",
-      "license": "MIT",
       "dependencies": {
         "debug": "^3.1.0",
         "node-ensure": "^0.0.0"

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "cheerio": "^1.0.0",
     "dotenv": "^16.4.5",
     "json-schema": "^0.4.0",
-    "mammoth": "^1.9.0",
+    "mammoth": "^1.9.1",
     "pdf-parse": "^1.1.1",
     "zod": "^3.22.4"
   },


### PR DESCRIPTION
This commit introduces the capability to extract text content from PDF and DOCX files retrieved from Moodle.

Key changes:
- Added `pdf-parse` and `mammoth` as dependencies to handle PDF and DOCX parsing respectively.
- Modified the `getResourceFileContent` method in `MoodleApiClient` to:
  - Use `pdf-parse` to extract text from PDF files.
  - Use `mammoth` to extract raw text from DOCX files.
- Removed placeholder warnings for unimplemented PDF/DOCX parsing.
- I will now be able to provide actual text content for these file types when they are part of Moodle resources.

This addresses the issue where I would return a placeholder message instead of the actual content for PDF and DOCX files. Manual testing steps have been outlined to verify these changes in a Moodle environment.